### PR TITLE
temp fix for Open-CE 1.3 and py39

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   string: py_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
   noarch: python
   script: python -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,8 @@ requirements:
      - tqdm {{ tqdm }}
      - dataclasses {{ dataclasses }}                    #[py<37]
      - typing_extensions {{ typing_extensions }}        #[py<38]
-     - importlib_resources {{ importlib_resources }}    #[py<39]
+       # temporary fix for 1.3 and py39
+     - importlib_resources 3.3.*  #[py<39]
      - tensorflow-base {{ tensorflow }}
 
 about:


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

The `tensorflow-datasets` recipe is listed as noarch, but has some python version conditional dependencies listed.
If this recipe is built using py37 and then runs on py39, the conditional deps will be pulled in.
That's not in itself terrible, but our pinned version of `importlib_resources` is not available from defaults for py39.
So, for Open-CE 1.3, manually pin `importlib_resources` to 3.3.* so that 3.3.1 can be picked for py39.

We'll rework this recipe to be not `noarch` for the next version.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
